### PR TITLE
Update to allow access_key for version 2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Then insert a new hotword into the `hotwords` section
     "blueberry": {
       "module": "porcupine_wakeword_plug",
       "keyword_file_path": "~/.mycroft/blueberry_linux.ppn",
-      "sensitivity": 0.5
+      "sensitivity": 0.5,
+      "access_key": <your_access_key>
     }
 ```
 

--- a/mycroft_porcupine_plugin/__init__.py
+++ b/mycroft_porcupine_plugin/__init__.py
@@ -27,6 +27,7 @@ class PorcupineWakeword(HotWordEngine):
         keyword_file_paths = [expanduser(x.strip()) for x in self.config.get(
             "keyword_file_path", "hey_mycroft.ppn").split(',')]
         sensitivities = self.config.get("sensitivities", 0.5)
+        access_key = self.config.get("access_key", None)
 
         try:
             import pvporcupine
@@ -46,10 +47,12 @@ class PorcupineWakeword(HotWordEngine):
         self.has_found = False
         self.num_keywords = len(keyword_file_paths)
 
+
         LOG.info(
             'Loading Porcupine using keyword path {} and sensitivities {}'
             .format(keyword_file_paths, sensitivities))
         self.porcupine = pvporcupine.create(
+            access_key,
             keyword_paths=keyword_file_paths,
             sensitivities=sensitivities)
 

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ PLUGIN_ENTRY_POINT = ('porcupine_wakeword_plug = '
 
 setup(
     name='mycroft-porcupine-plugin',
-    version='0.2.2',
+    version='0.2.1',
     description='A Porcupine wakeword plugin for mycroft',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author='BuiderJer',
-    author_email='builderjer@gmail.com',
+    author='Åke Forslund',
+    author_email='ake.forslund@gmail.com',
     packages=['mycroft_porcupine_plugin'],
     keywords='mycroft plugin wakeword',
     entry_points={'mycroft.plugin.wake_word': PLUGIN_ENTRY_POINT},

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ PLUGIN_ENTRY_POINT = ('porcupine_wakeword_plug = '
 
 setup(
     name='mycroft-porcupine-plugin',
-    version='0.2.1',
+    version='0.2.2',
     description='A Porcupine wakeword plugin for mycroft',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author='Åke Forslund',
-    author_email='ake.forslund@gmail.com',
+    author='BuiderJer',
+    author_email='builderjer@gmail.com',
     packages=['mycroft_porcupine_plugin'],
     keywords='mycroft plugin wakeword',
     entry_points={'mycroft.plugin.wake_word': PLUGIN_ENTRY_POINT},


### PR DESCRIPTION

#### Description
Fixes issue [#2](https://github.com/forslund/mycroft-porcupine-plugin/issues/2)

#### Type of PR
I
- [ X] Feature implementation

#### Testing
Create a free account at [picovoice.ai](https://picovoice.ai/)
Follow documentation for creating an access_key
Add your access_key to the configuration file

#### CLA
I believe that I signed one of these a couple of years ago, but will again if necessary.
